### PR TITLE
Allow ESR version numbers to be handled through an overall HUP action

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,14 +29,13 @@ export const actionsConfig: ActionsConfig = {
 			minTargetVersion: '2.2.0+rev1',
 			maxTargetVersion: '2.5.1+rev1',
 		},
-		resinhup22: {
+		balenahup: {
 			minSourceVersion: '2.0.0+rev1',
-			targetMajorVersion: 2,
 			minTargetVersion: '2.2.0+rev1',
 		},
 	},
 	deviceTypesDefaults: {
-		resinhup22: {},
+		balenahup: {},
 	},
 	deviceTypes: {
 		'raspberry-pi': {
@@ -70,7 +69,7 @@ export const actionsConfig: ActionsConfig = {
 			},
 		},
 		'intel-edison': {
-			resinhup22: {
+			balenahup: {
 				minTargetVersion: '2.9.7+rev2',
 			},
 		},
@@ -79,27 +78,27 @@ export const actionsConfig: ActionsConfig = {
 			resinhup12: {},
 		},
 		'jetson-tx2': {
-			resinhup22: {
+			balenahup: {
 				minSourceVersion: '2.7.4',
 			},
 		},
 		qemux86: {
-			resinhup22: {
+			balenahup: {
 				minSourceVersion: '2.9.3',
 			},
 		},
 		'qemux86-64': {
-			resinhup22: {
+			balenahup: {
 				minSourceVersion: '2.9.3',
 			},
 		},
 		skx2: {
-			resinhup22: {
+			balenahup: {
 				minSourceVersion: '2.7.4',
 			},
 		},
 		ts4900: {
-			resinhup22: {
+			balenahup: {
 				minSourceVersion: '2.4.1',
 			},
 		},

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,13 +14,13 @@
 	limitations under the License.
 */
 
-export type ActionName = 'resinhup11' | 'resinhup12' | 'resinhup22';
+export type ActionName = 'resinhup11' | 'resinhup12' | 'balenahup';
 
 export interface ActionConfig {
 	// the minimum resinOS source version, that the upgrade can be done for, includes this version
 	minSourceVersion: string;
 	// the the major version of the resinOS target that the script applies to
-	targetMajorVersion: number;
+	targetMajorVersion?: number;
 	// the minimum resinOS target version to upgrade to, includes this version
 	minTargetVersion: string;
 	// first resinOS version within the major version, that the updater can no longer target (update only to strictly lower versions than this)

--- a/tests/01-actions.spec.ts
+++ b/tests/01-actions.spec.ts
@@ -406,7 +406,7 @@ describe('BalenaHupActionUtils', () => {
 				});
 			});
 
-			it('Should return resinhup22 for supported v2 -> v2 hup versions', () => {
+			it('Should return balenahup for supported v2 -> v2 hup versions', () => {
 				['raspberry-pi', 'raspberrypi3', 'beaglebone-pocket'].forEach(
 					deviceType => {
 						expect(
@@ -415,33 +415,33 @@ describe('BalenaHupActionUtils', () => {
 								'2.0.0+rev1.prod',
 								'2.2.0+rev1.prod',
 							),
-						).to.equal('resinhup22');
+						).to.equal('balenahup');
 						expect(
 							hupActionHelper.getHUPActionType(
 								deviceType,
 								'2.1.0+rev1.prod',
 								'2.2.0+rev1.prod',
 							),
-						).to.equal('resinhup22');
+						).to.equal('balenahup');
 						expect(
 							hupActionHelper.getHUPActionType(
 								deviceType,
 								'2.0.0+rev1.prod',
 								'2.29.2+rev1.prod',
 							),
-						).to.equal('resinhup22');
+						).to.equal('balenahup');
 						expect(
 							hupActionHelper.getHUPActionType(
 								deviceType,
 								'2.9.6+rev2.prod',
 								'2.29.2+rev1.prod',
 							),
-						).to.equal('resinhup22');
+						).to.equal('balenahup');
 					},
 				);
 			});
 
-			it('Should return resinhup22 for supported v2 -> v2 hup versions for special device types', () => {
+			it('Should return balenahup for supported v2 -> v2 hup versions for special device types', () => {
 				['jetson-tx2', 'skx2'].forEach(deviceType => {
 					expect(
 						hupActionHelper.getHUPActionType(
@@ -449,33 +449,166 @@ describe('BalenaHupActionUtils', () => {
 							'2.7.4',
 							'2.29.0+rev1.prod',
 						),
-					).to.equal('resinhup22');
+					).to.equal('balenahup');
 					expect(
 						hupActionHelper.getHUPActionType(
 							deviceType,
 							'2.7.4+rev1.prod',
 							'2.29.0+rev1.prod',
 						),
-					).to.equal('resinhup22');
+					).to.equal('balenahup');
 					expect(
 						hupActionHelper.getHUPActionType(
 							deviceType,
 							'2.7.4+rev1.prod',
 							'2.7.8+rev1.prod',
 						),
-					).to.equal('resinhup22');
+					).to.equal('balenahup');
 					expect(
 						hupActionHelper.getHUPActionType(
 							deviceType,
 							'2.9.6+rev2.prod',
 							'2.29.2+rev1.prod',
 						),
-					).to.equal('resinhup22');
+					).to.equal('balenahup');
 				});
 			});
 		});
 
-		it('Should error when attemptiong v1 -> v3 hup', () => {
+		describe('v2 -> ESR', () => {
+			it('Should return balenahup for supported v2 -> ESR hup versions', () => {
+				['raspberry-pi', 'raspberrypi3', 'beaglebone-pocket'].forEach(
+					deviceType => {
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2.0.0+rev1.prod',
+								'2019.07.0.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2.1.0+rev1.prod',
+								'2019.07.0.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2.0.0+rev1.prod',
+								'2019.07.0.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2.9.6+rev2.prod',
+								'2019.07.0.prod',
+							),
+						).to.equal('balenahup');
+					},
+				);
+			});
+
+			it('Should return balenahup for supported v2 -> ESR hup versions for special device types', () => {
+				['jetson-tx2', 'skx2'].forEach(deviceType => {
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2.7.4',
+							'2019.07.0.prod',
+						),
+					).to.equal('balenahup');
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2.7.4+rev1.prod',
+							'2019.07.0.prod',
+						),
+					).to.equal('balenahup');
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2.9.6+rev2.prod',
+							'2019.07.0.prod',
+						),
+					).to.equal('balenahup');
+				});
+			});
+		});
+
+		describe('ESR -> ESR', () => {
+			it('Should return balenahup for supported ESR -> ESR hup versions', () => {
+				['raspberry-pi', 'raspberrypi3', 'beaglebone-pocket'].forEach(
+					deviceType => {
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2019.07.0.prod',
+								'2019.07.1.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2019.07.0.prod',
+								'2019.11.0.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2019.07.0.prod',
+								'2019.11.1.prod',
+							),
+						).to.equal('balenahup');
+						expect(
+							hupActionHelper.getHUPActionType(
+								deviceType,
+								'2019.07.0.prod',
+								'2020.07.0.prod',
+							),
+						).to.equal('balenahup');
+					},
+				);
+			});
+
+			it('Should return balenahup for supported ESR -> ESR hup versions for special device types', () => {
+				['jetson-tx2', 'skx2'].forEach(deviceType => {
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2019.07.0.prod',
+							'2019.07.1.prod',
+						),
+					).to.equal('balenahup');
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2019.07.0.prod',
+							'2019.11.0.prod',
+						),
+					).to.equal('balenahup');
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2019.07.0.prod',
+							'2019.11.1.prod',
+						),
+					).to.equal('balenahup');
+					expect(
+						hupActionHelper.getHUPActionType(
+							deviceType,
+							'2019.07.0.prod',
+							'2020.07.0.prod',
+						),
+					).to.equal('balenahup');
+				});
+			});
+		});
+
+		it('Should error when attempting v1 -> v3 hup', () => {
 			['raspberry-pi', 'raspberrypi3'].forEach(deviceType => {
 				expect(() =>
 					hupActionHelper.getHUPActionType(
@@ -484,36 +617,32 @@ describe('BalenaHupActionUtils', () => {
 						'3.0.1+rev1.prod',
 					),
 				).to.throw(
-					`This update request cannot be performed on '${deviceType}'`,
+					`This update request cannot be performed from 1.30.1 to 3.0.1+rev1.prod`,
 				);
 			});
 		});
 
-		it('Should error when attemptiong v2 -> v3 hup', () => {
+		it('Should return balenahup when attempting v2 -> v3 hup', () => {
 			['raspberry-pi', 'raspberrypi3'].forEach(deviceType => {
-				expect(() =>
+				expect(
 					hupActionHelper.getHUPActionType(
 						deviceType,
 						'2.9.6+rev2.prod',
 						'3.0.1+rev1.prod',
 					),
-				).to.throw(
-					`This update request cannot be performed on '${deviceType}'`,
-				);
+				).to.equal('balenahup');
 			});
 		});
 
-		it('Should error when attemptiong v3 -> v3 hup', () => {
+		it('Should return balenahup when attempting v3 -> v3 hup', () => {
 			['raspberry-pi', 'raspberrypi3'].forEach(deviceType => {
-				expect(() =>
+				expect(
 					hupActionHelper.getHUPActionType(
 						deviceType,
 						'3.0.0+rev1.prod',
 						'3.0.1+rev1.prod',
 					),
-				).to.throw(
-					`This update request cannot be performed on '${deviceType}'`,
-				);
+				).to.equal('balenahup');
 			});
 		});
 	});

--- a/tests/02-validations.spec.ts
+++ b/tests/02-validations.spec.ts
@@ -523,7 +523,7 @@ describe('BalenaHupActionUtils', () => {
 			});
 		});
 
-		it('Should return false when attemptiong v2 -> v3 hup', () => {
+		it('Should return true when attemptiong v2 -> v3 hup', () => {
 			['raspberry-pi', 'raspberrypi3'].forEach(deviceType => {
 				expect(
 					hupActionHelper.isSupportedOsUpdate(
@@ -531,11 +531,11 @@ describe('BalenaHupActionUtils', () => {
 						'2.9.6+rev2.prod',
 						'3.0.1+rev1.prod',
 					),
-				).to.equal(false);
+				).to.equal(true);
 			});
 		});
 
-		it('Should return false when attemptiong v3 -> v3 hup', () => {
+		it('Should return true when attemptiong v3 -> v3 hup', () => {
 			['raspberry-pi', 'raspberrypi3'].forEach(deviceType => {
 				expect(
 					hupActionHelper.isSupportedOsUpdate(
@@ -543,7 +543,7 @@ describe('BalenaHupActionUtils', () => {
 						'3.0.0+rev1.prod',
 						'3.0.1+rev1.prod',
 					),
-				).to.equal(false);
+				).to.equal(true);
 			});
 		});
 	});


### PR DESCRIPTION
1.x->1.x and 1.x->2.x updates are handled the same way as before, but
2.x->2.x updates and 2.x->ESR / ESR->ESR updates (with version numbers
like `2019.07.0`) are unified into a single update action.

Depends-on: https://github.com/balena-io/resin-proxy/pull/388
Change-type: major
Signed-off-by: Gergely Imreh <gergely@balena.io>