### PR TITLE
Fix function checking development releases

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,7 +27,7 @@ const isDevVariant = (version: string): boolean => {
 	if (parsed == null) {
 		return false;
 	}
-	return includes(parsed.build.concat(parsed.prerelease), 'dev');
+	return includes([...parsed.build, ...parsed.prerelease], 'dev');
 };
 
 export class HUPActionHelper {


### PR DESCRIPTION
Likely due to some recent changes, the previous code was not compiling:
```
lib/index.ts:30:38 - error TS2345: Argument of type 'readonly (string | number)[]' is not assignable to parameter of type 'string | ConcatArray<string>'.
  Type 'readonly (string | number)[]' is not assignable to type 'string'.

30  return includes(parsed.build.concat(parsed.prerelease), 'dev');
                                        ~~~~~~~~~~~~~~~~~
```
Using the spread operator this can be resolved and the items are
concatenated correctly.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>