### PR TITLE
balenahup: add support for "raspberrypi3-64" device type HUPs

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -50,6 +50,9 @@ export const actionsConfig: ActionsConfig = {
 			resinhup11: {},
 			resinhup12: {},
 		},
+		'raspberrypi3-64': {
+			balenahup: {},
+		},
 		'beaglebone-black': {
 			resinhup11: {},
 			resinhup12: {


### PR DESCRIPTION
Connects-to: #13
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>