### PR TITLE
Alternative addition of takeover like PR #35

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -83,10 +83,10 @@ export const actionsConfig: ActionsConfig = {
 			},
 		},
 		'jetson-xavier-nx-devkit-emmc': {
-			takeover: {
+			balenahup: {
 				// NOTE: this version is here as a placeholder for
 				// testing. Replace with the correct version before merging
-				minTargetVersion: '5.1.45+rev1',
+				minTakeoverVersion: '5.1.45+rev1',
 			},
 		},
 		qemux86: {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,6 +17,9 @@
 import type { ActionsConfig } from './types';
 
 export const actionsConfig: ActionsConfig = {
+	// 'takeover' is an ActionName, but we do not define an ActionsConfig for it.
+	// The name is used only as a result of processing a 'balenahup' ActionConfig.
+	// See the deviceTypes entries below that define a minTakeoverVersion.
 	actions: {
 		resinhup11: {
 			minSourceVersion: '1.8.0',
@@ -82,11 +85,19 @@ export const actionsConfig: ActionsConfig = {
 				minSourceVersion: '2.7.4',
 			},
 		},
+		'jetson-xavier': {
+			balenahup: {
+				minTakeoverVersion: '6.0.50',
+			},
+		},
+		'jetson-xavier-nx-devkit': {
+			balenahup: {
+				minTakeoverVersion: '6.0.50+rev1',
+			},
+		},
 		'jetson-xavier-nx-devkit-emmc': {
 			balenahup: {
-				// NOTE: this version is here as a placeholder for
-				// testing. Replace with the correct version before merging
-				minTakeoverVersion: '5.1.45+rev1',
+				minTakeoverVersion: '6.0.39',
 			},
 		},
 		qemux86: {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -14,7 +14,7 @@
 	limitations under the License.
 */
 
-import { ActionsConfig } from './types';
+import type { ActionsConfig } from './types';
 
 export const actionsConfig: ActionsConfig = {
 	actions: {
@@ -80,6 +80,13 @@ export const actionsConfig: ActionsConfig = {
 		'jetson-tx2': {
 			balenahup: {
 				minSourceVersion: '2.7.4',
+			},
+		},
+		'jetson-xavier-nx-devkit-emmc': {
+			takeover: {
+				// NOTE: this version is here as a placeholder for
+				// testing. Replace with the correct version before merging
+				minTargetVersion: '5.1.45+rev1',
 			},
 		},
 		qemux86: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -72,7 +72,7 @@ export class HUPActionHelper {
 		deviceType: string,
 		currentVersion: string,
 		targetVersion: string,
-	): ActionName | 'takeover' {
+	): ActionName {
 		const currentVersionParsed = bSemver.parse(currentVersion);
 		if (currentVersionParsed == null) {
 			throw new HUPActionError('Invalid current balenaOS version');
@@ -120,13 +120,9 @@ export class HUPActionHelper {
 					);
 			}
 		} else {
-			// // Takeover overrides the checks below for the device type
-			// if (this.isTakeoverRequired(deviceType, currentVersion, targetVersion)) {
-			// 	return 'takeover';
-			// }
+			// actionName may change below to 'takeover'
 			actionName = 'balenahup';
 		}
-
 		const { actionsConfig } = this;
 		const defaultActions = actionsConfig.deviceTypesDefaults;
 		const deviceActions = actionsConfig.deviceTypes[deviceType] || {};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,19 +25,17 @@ export interface ActionConfig {
 	minTargetVersion: string;
 	// first resinOS version within the major version, that the updater can no longer target (update only to strictly lower versions than this)
 	maxTargetVersion?: string;
+	// first balenaOS version that requires a takeover rather than a balenahup. An update with a target larger or equal to this version
+	// coming from a source version before it will require a takeover rather than a HUP
+	minTakeoverVersion?: string;
 }
-
-// The per device configuration can override the version configuration of the
-// action, or define a 'takeover' version when a jump between two versions
-// cannot be done with balenahup, but needs a full re-flash
-type DeviceTypeConfig = {
-	[K in ActionName]?: Partial<ActionConfig>;
-} & { takeover?: Pick<ActionConfig, 'minTargetVersion'> };
 
 export interface ActionsConfig {
 	actions: { [K in ActionName]: ActionConfig };
 	deviceTypesDefaults: { [K in ActionName]?: Partial<ActionConfig> };
 	deviceTypes: Partial<{
-		[deviceTypeSlug: string]: DeviceTypeConfig;
+		[deviceTypeSlug: string]: {
+			[K in ActionName]?: Partial<ActionConfig>;
+		};
 	}>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,10 +27,17 @@ export interface ActionConfig {
 	maxTargetVersion?: string;
 }
 
+// The per device configuration can override the version configuration of the
+// action, or define a 'takeover' version when a jump between two versions
+// cannot be done with balenahup, but needs a full re-flash
+type DeviceTypeConfig = {
+	[K in ActionName]?: Partial<ActionConfig>;
+} & { takeover?: Pick<ActionConfig, 'minTargetVersion'> };
+
 export interface ActionsConfig {
 	actions: { [K in ActionName]: ActionConfig };
 	deviceTypesDefaults: { [K in ActionName]?: Partial<ActionConfig> };
 	deviceTypes: Partial<{
-		[deviceTypeSlug: string]: { [K in ActionName]?: Partial<ActionConfig> };
+		[deviceTypeSlug: string]: DeviceTypeConfig;
 	}>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,7 @@
 	limitations under the License.
 */
 
-export type ActionName = 'resinhup11' | 'resinhup12' | 'balenahup';
+export type ActionName = 'resinhup11' | 'resinhup12' | 'balenahup' | 'takeover';
 
 export interface ActionConfig {
 	// the minimum resinOS source version, that the upgrade can be done for, includes this version
@@ -31,7 +31,9 @@ export interface ActionConfig {
 }
 
 export interface ActionsConfig {
-	actions: { [K in ActionName]: ActionConfig };
+	// We do not define an ActionConfig for the 'takeover' ActionName.
+	// The name is used only as a result of processing a 'balenahup' ActionConfig.
+	actions: { [K in ActionName]?: ActionConfig };
 	deviceTypesDefaults: { [K in ActionName]?: Partial<ActionConfig> };
 	deviceTypes: Partial<{
 		[deviceTypeSlug: string]: {

--- a/tests/01-actions.spec.ts
+++ b/tests/01-actions.spec.ts
@@ -734,10 +734,10 @@ describe('BalenaHupActionUtils', () => {
 			[
 				{
 					deviceType: 'jetson-xavier-nx-devkit-emmc',
-					before: '5.0.0',
-					cutoff: '5.1.45',
-					takeover: '5.1.45+rev1',
-					after: '5.2.0',
+					before: '6.0.0',
+					cutoff: '6.0.38',
+					takeover: '6.0.39',
+					after: '6.1.0',
 				},
 			].forEach(({ deviceType, before, cutoff, takeover, after }) => {
 				it(`should return 'balenahup' if doing HUP for ${deviceType} to a version before ${takeover}`, () => {

--- a/tests/01-actions.spec.ts
+++ b/tests/01-actions.spec.ts
@@ -729,5 +729,35 @@ describe('BalenaHupActionUtils', () => {
 				).to.equal('balenahup');
 			});
 		});
+
+		describe('takeover', () => {
+			[
+				{
+					deviceType: 'jetson-xavier-nx-devkit-emmc',
+					before: '5.0.0',
+					cutoff: '5.1.45',
+					takeover: '5.1.45+rev1',
+					after: '5.2.0',
+				},
+			].forEach(({ deviceType, before, cutoff, takeover, after }) => {
+				it(`should return 'balenahup' if doing HUP for ${deviceType} to a version before ${takeover}`, () => {
+					expect(
+						hupActionHelper.getHUPActionType(deviceType, before, cutoff),
+					).to.equal('balenahup');
+				});
+
+				it(`should return 'takeover' if doing HUP for ${deviceType} to a version after ${takeover}`, () => {
+					expect(
+						hupActionHelper.getHUPActionType(deviceType, before, after),
+					).to.equal('takeover');
+				});
+
+				it(`should return 'balenahup' if doing HUP for ${deviceType} from a version after ${takeover}`, () => {
+					expect(
+						hupActionHelper.getHUPActionType(deviceType, takeover, after),
+					).to.equal('balenahup');
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
This PR adds a commit to use _takeover_ as an ActionName to simplify use of `getHUPActionType()` by clients.

It is intended for discussion on PR #35.